### PR TITLE
add account_id to extras

### DIFF
--- a/lib/omniauth/strategies/smile.rb
+++ b/lib/omniauth/strategies/smile.rb
@@ -24,7 +24,7 @@ module OmniAuth
 
       extra do
         {
-          account_id: access_token.params["smile_account_id"]
+          account_id: access_token.params['smile_account_id']
         }
       end
 

--- a/lib/omniauth/strategies/smile.rb
+++ b/lib/omniauth/strategies/smile.rb
@@ -22,6 +22,12 @@ module OmniAuth
         }
       end
 
+      extra do
+        {
+          account_id: access_token.params["smile_account_id"]
+        }
+      end
+
       ##
       # @return [String] Base callback URI without the params since adding the params in (which is default) makes the Smile API return a 4xx error
       def callback_base_url

--- a/omniauth-smile.gemspec
+++ b/omniauth-smile.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
   s.required_ruby_version = '>= 2.1.9'
 
-  s.add_runtime_dependency 'omniauth-oauth2', '~> 1.5.0'
+  s.add_runtime_dependency 'omniauth-oauth2'
   s.add_runtime_dependency 'activesupport'
 
   s.add_development_dependency 'rake'

--- a/omniauth-smile.gemspec
+++ b/omniauth-smile.gemspec
@@ -5,10 +5,10 @@ require 'omniauth/smile/version'
 Gem::Specification.new do |s|
   s.name     = 'omniauth-smile'
   s.version  = OmniAuth::Smile::VERSION
-  s.authors  = ['Jay El-Kaake']
-  s.email    = ['dev@feracommerce.com']
+  s.authors  = ['Jay El-Kaake', 'Jonathon Ramey']
+  s.email    = ['dev@feracommerce.com', 'jonathon627@gmail.com']
   s.summary  = 'Smile strategy for OmniAuth'
-  s.homepage = 'https://github.com/feracommerce/omniauth-smile'
+  s.homepage = 'https://github.com/jtramey/omniauth-smile'
   s.license = 'MIT'
 
   s.files         = `git ls-files`.split("\n")

--- a/omniauth-smile.gemspec
+++ b/omniauth-smile.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.authors  = ['Jay El-Kaake', 'Jonathon Ramey']
   s.email    = ['dev@feracommerce.com', 'jonathon627@gmail.com']
   s.summary  = 'Smile strategy for OmniAuth'
-  s.homepage = 'https://github.com/jtramey/omniauth-smile'
+  s.homepage = 'https://github.com/feracommerce/omniauth-smile'
   s.license = 'MIT'
 
   s.files         = `git ls-files`.split("\n")


### PR DESCRIPTION
https://docs-next.smile.io/integrate-your-product/build-a-smile-app/oauth-reference

Smile.io has added `smile_account_id` to their oauth token response. 
smile_account_id: The Smile account ID for the user that authorized the client.

This PR adds that to the extra section for Omniauth.

Let me know if there's anything else that needs to be done. Thanks.